### PR TITLE
Fixes error about 'private method XYZ called for Restforce:Configuration

### DIFF
--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -55,7 +55,6 @@ module Restforce
         self
       end
 
-    private
       attr_reader :default
       alias_method :default_provided?, :default
 

--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -61,7 +61,7 @@ module Restforce
       def write_attribute
         configuration.send :attr_accessor, name
       end
-
+    private
       def define_method
         our_default = default
         our_name    = name

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -58,7 +58,8 @@ describe Restforce do
      :proxy_uri, :authentication_callback, :mashify].each do |attr|
       it "allows #{attr} to be set" do
         Restforce.configure do |config|
-          config.send("#{attr}=", 'foobar')
+          #Using eval ensures private properties aren't inadvertently assigned to
+          eval "config.#{attr}= 'foobar'"
         end
         expect(Restforce.configuration.send(attr)).to eq 'foobar'
       end


### PR DESCRIPTION
This addresses the open issue #98 -- I was only able to repro this problem on Ruby 1.9.2 -- not on Ruby 2.0.0

When I changed the spec to use eval() instead of send(), I got what @bramswenson anticipated (log below) -- removing the private section of the Option class resolved the spec failure

```
  1) Restforce#configure allows authentication_callback to be set
     Failure/Error: eval "config.#{attr}= 'foobar'"
     NoMethodError:
       private method `authentication_callback=' called for #<Restforce::Configuration:0x0000000438e650>
     # ./spec/unit/config_spec.rb:61:in `eval'
     # ./spec/unit/config_spec.rb:61:in `eval'
     # ./spec/unit/config_spec.rb:61:in `block (5 levels) in <top (required)>'
     # ./lib/restforce/config.rb:26:in `configure'
     # ./spec/unit/config_spec.rb:60:in `block (4 levels) in <top (required)>'

  2) Restforce#configure allows mashify to be set
     Failure/Error: eval "config.#{attr}= 'foobar'"
     NoMethodError:
       private method `mashify=' called for #<Restforce::Configuration:0x0000000438b360>
     # ./spec/unit/config_spec.rb:61:in `eval'
     # ./spec/unit/config_spec.rb:61:in `eval'
     # ./spec/unit/config_spec.rb:61:in `block (5 levels) in <top (required)>'
     # ./lib/restforce/config.rb:26:in `configure'
     # ./spec/unit/config_spec.rb:60:in `block (4 levels) in <top (required)>'
```