### PR TITLE
Allow hashie 2.1.x, test suite passes

### DIFF
--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'faraday', '~> 0.8.4'
   gem.add_dependency 'faraday_middleware', '>= 0.8.8'
   gem.add_dependency 'json', ['>= 1.7.5', '< 1.9.0']
-  gem.add_dependency 'hashie', ['>= 1.2.0', '< 2.1']
+  gem.add_dependency 'hashie', ['>= 1.2.0', '< 2.2']
 
   gem.add_development_dependency 'rspec', '~> 2.14.0'
   gem.add_development_dependency 'webmock', '~> 1.13.0'


### PR DESCRIPTION
Requiring hashie < 2.1 creates a conflict with grape 0.8.0 which requires hashie >= 2.1.