### PR TITLE
Make logger a config option

### DIFF
--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -132,9 +132,8 @@ module Restforce
     # A Proc that is called with the response body after a successful authentication.
     option :authentication_callback
 
-    def logger
-      @logger ||= ::Logger.new STDOUT
-    end
+    # The logger to use for logging information about requests and responses
+    option :logger, :default => lambda { ::Logger.new STDOUT }
 
     def options
       self.class.options

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -55,7 +55,7 @@ describe Restforce do
   describe '#configure' do
     [:username, :password, :security_token, :client_id, :client_secret, :compress, :timeout,
      :oauth_token, :refresh_token, :instance_url, :api_version, :host, :authentication_retries,
-     :proxy_uri, :authentication_callback, :mashify].each do |attr|
+     :proxy_uri, :authentication_callback, :mashify, :logger].each do |attr|
       it "allows #{attr} to be set" do
         Restforce.configure do |config|
           config.send("#{attr}=", 'foobar')


### PR DESCRIPTION
I'd really like to be able to configure Restforce to use `Rails.logger` rather than logging to STDOUT. Then in my various environments I can have Restforce logs alongside my Rails logs. It would really help for debugging.