### PR TITLE
Dupe attributes in `update!`

### DIFF
--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -220,6 +220,7 @@ module Restforce
       # Returns true if the sobject was successfully updated.
       # Raises an exception if an error is returned from Salesforce.
       def update!(sobject, attrs)
+        attrs = attrs.dup
         id = attrs.delete(attrs.keys.find { |k| k.to_s.downcase == 'id' })
         raise ArgumentError, 'Id field missing from attrs.' unless id
         api_patch "sobjects/#{sobject}/#{id}", attrs

--- a/spec/unit/concerns/api_spec.rb
+++ b/spec/unit/concerns/api_spec.rb
@@ -177,12 +177,13 @@ describe Restforce::Concerns::API do
     subject(:result) { client.update!(sobject, attrs) }
 
     context 'when the id field is present' do
-      let(:attrs) { { :id => '1234' } }
+      let(:attrs) { { :id => '1234', :foo => 'bar' } }
 
       it 'sends an HTTP PATCH, and returns true' do
         client.should_receive(:api_patch).
-          with('sobjects/Whizbang/1234', attrs)
+          with('sobjects/Whizbang/1234', { :foo => 'bar' })
         expect(result).to be_true
+        expect(attrs[:id]).to eql '1234'
       end
     end
 


### PR DESCRIPTION
Previously the `id` was removed from the hash in the caller.