### PR TITLE
Allow Hashie 3 or lower

### DIFF
--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'faraday', '~> 0.9.0'
   gem.add_dependency 'faraday_middleware', '>= 0.8.8'
   gem.add_dependency 'json', ['>= 1.7.5', '< 1.9.0']
-  gem.add_dependency 'hashie', ['>= 1.2.0', '< 2.1']
+  gem.add_dependency 'hashie', ['>= 1.2.0', '<= 3.3.1']
 
   gem.add_development_dependency 'rspec', '~> 2.14.0'
   gem.add_development_dependency 'webmock', '~> 1.13.0'


### PR DESCRIPTION
I use a gem that requires Hashie > 3.0 and it is causing a gem conflict with RestForce.

I upgraded the dependency to allow for 3.0 and ran the specs and they run clean. I also when through the list 
https://github.com/intridea/hashie/blob/master/UPGRADING.md and RestForce does not seem to be affected by any of the Hashie 3 changes.