### PR TITLE
Use TLS 1.0 encryption (Salesforce is disabling SSL 3.0)

### DIFF
--- a/lib/restforce/concerns/connection.rb
+++ b/lib/restforce/concerns/connection.rb
@@ -59,7 +59,9 @@ module Restforce
         { :request => {
             :timeout => options[:timeout],
             :open_timeout => options[:timeout] },
-          :proxy => options[:proxy_uri]
+          :proxy => options[:proxy_uri],
+          # Salesforce now requires TLS 1.0 encryption, please see #146.
+          :ssl => {:version => 'TLSv1'}
         }
       end
 


### PR DESCRIPTION
Please see ejholmes/restforce#146.