### PR TITLE
Allows logger to be configured.

### DIFF
--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -132,6 +132,9 @@ module Restforce
     # A Proc that is called with the response body after a successful authentication.
     option :authentication_callback
 
+    # The logger to use during logging. e.g. Logger.new('log/restforce.log')
+    option :logger
+
     def logger
       @logger ||= ::Logger.new STDOUT
     end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -55,7 +55,7 @@ describe Restforce do
   describe '#configure' do
     [:username, :password, :security_token, :client_id, :client_secret, :compress, :timeout,
      :oauth_token, :refresh_token, :instance_url, :api_version, :host, :authentication_retries,
-     :proxy_uri, :authentication_callback, :mashify].each do |attr|
+     :proxy_uri, :authentication_callback, :mashify, :logger].each do |attr|
       it "allows #{attr} to be set" do
         Restforce.configure do |config|
           config.send("#{attr}=", 'foobar')


### PR DESCRIPTION
Creates getter and setter for @logger on Restforce.configuration.