### PR TITLE
Add recent method to the Restforce client

### DIFF
--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -319,16 +319,25 @@ module Restforce
       # id      - The id of the record. If field is specified, id should be the id
       #           of the external field.
       # select  - A String array denoting the fields to select.  If nil or empty array
-      #           is passed, all fields are selected.  
+      #           is passed, all fields are selected.
       # field   - External ID field to use (default: nil).
       #
       def select(sobject, id, select, field=nil)
         path = field ? "sobjects/#{sobject}/#{field}/#{id}" : "sobjects/#{sobject}/#{id}"
         path << "?fields=#{select.join(",")}" if select && select.any?
-        
+
         api_get(path).body
       end
 
+      # Public: Finds recently viewed items for the logged-in user.
+      # limit - An optional limit that specifies the maximum number of records to be returned.
+      #         If this parameter is not specified, the default maximum number of records returned
+      #         is the maximum number of entries in RecentlyViewed, which is 200 records per object.
+      # Returns an array of the recently viewed Restforce::SObject records.
+      def recent(limit = nil)
+        path = limit ? "recent?limit=#{limit}" : "recent"
+        api_get(path).body
+      end
 
     private
 

--- a/spec/unit/concerns/api_spec.rb
+++ b/spec/unit/concerns/api_spec.rb
@@ -306,4 +306,26 @@ describe Restforce::Concerns::API do
       end
     end
   end
+
+  describe "#recent" do
+    context "given no limit is specified" do
+      it "returns the most recently viewed items for the logged-in user" do
+        client.should_receive(:api_get).
+          with('recent').
+          and_return(response)
+        result = client.recent
+        expect(result).to eq response.body
+      end
+    end
+
+    context "given a limit is specified" do
+      it "returns up to the limit specified results" do
+        client.should_receive(:api_get).
+          with('recent?limit=10').
+          and_return(response)
+        result = client.recent(10)
+        expect(result).to eq response.body
+      end
+    end
+  end
 end


### PR DESCRIPTION
Update the client to support the 'recent' method of the REST API.