### PR TITLE
add support for query_all in api version 29+

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ account.destroy
 # => true
 ```
 
+### query_all
+
+```ruby
+accounts = client.query_all("select Id, Something__c from Account where isDeleted = true")
+# => #<Restforce::Collection >
+
+query_all allows you to include results from your query that Salesforce hides in the default "query" method.  These include
+
+1. soft-deleted records
+2. archived records.  Task and Event records are usually archived automatically after they are a year old, but the rules are complex.
+
 ### find
 
 ```ruby

--- a/lib/restforce.rb
+++ b/lib/restforce.rb
@@ -39,6 +39,7 @@ module Restforce
   Error               = Class.new(StandardError)
   AuthenticationError = Class.new(Error)
   UnauthorizedError   = Class.new(Error)
+  UnsupportedError    = Class.new(Error)
 
   class << self
     # Alias for Restforce::Data::Client.new

--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -131,6 +131,29 @@ module Restforce
         mashify? ? response.body : response.body['records']
       end
 
+      # Public: Executs a SOQL query and returns the result.  Unlike the Query resource, QueryAll will return 
+      # records that have been deleted because of a merge or delete. QueryAll will also return information 
+      # about archived Task and Event records. QueryAll is available in API version 29.0 and later.
+      #
+      # soql - A SOQL expression.
+      #
+      # Examples
+      #
+      #   # Find the names of all Accounts
+      #   client.query_all('select Name from Account').map(&:Name)
+      #   # => ['Foo Bar Inc.', 'Whizbang Corp']
+      #
+      # Returns a Restforce::Collection if Restforce.configuration.mashify is true.
+      # Returns an Array of Hash for each record in the result if Restforce.configuration.mashify is false.
+      # Raises a Restforce::UnsupportedError if the connected api is less than 29.0
+      def query_all(soql)
+        if Restforce.configuration.api_version.to_f < 29.0
+          raise Restforce::UnsupportedError.new("query_all requires Api version 29.0 or later") 
+        end
+        response = api_get 'queryAll', :q => soql
+        mashify? ? response.body : response.body['records']
+      end
+
       # Public: Perform a SOSL search
       #
       # sosl - A SOSL expression.

--- a/spec/integration/abstract_client_spec.rb
+++ b/spec/integration/abstract_client_spec.rb
@@ -33,6 +33,17 @@ shared_examples_for Restforce::AbstractClient do
     it { should be_an Enumerable }
   end
 
+  describe '.query_all with supporterd api_version' do
+    before { Restforce.configuration.api_version = "30.0" }
+    after { Restforce.configuration.api_version = "26.0" }
+
+    requests 'queryAll\?q=SELECT%20some,%20fields%20FROM%20object', :fixture => 'sobject/query_success_response'
+    
+    subject { client.query_all('SELECT some, fields FROM object') }
+
+    it { should be_an Enumerable }
+  end
+
   describe '.search' do
     requests 'search\?q=FIND%20%7Bbar%7D', :fixture => 'sobject/search_success_response'
 

--- a/spec/integration/abstract_client_spec.rb
+++ b/spec/integration/abstract_client_spec.rb
@@ -34,8 +34,8 @@ shared_examples_for Restforce::AbstractClient do
   end
 
   describe '.query_all with supporterd api_version' do
-    before { Restforce.configuration.api_version = "30.0" }
-    after { Restforce.configuration.api_version = "26.0" }
+    before { Restforce.configuration.send("api_version=", "30.0")  }
+    after { Restforce.configuration.send("api_version=", "26.0") }
 
     requests 'queryAll\?q=SELECT%20some,%20fields%20FROM%20object', :fixture => 'sobject/query_success_response'
     

--- a/spec/unit/concerns/api_spec.rb
+++ b/spec/unit/concerns/api_spec.rb
@@ -127,8 +127,8 @@ describe Restforce::Concerns::API do
     subject(:results) { client.query_all(soql) }
 
     context "with supported api_version" do
-      before { Restforce.configuration.api_version = "31.0" }
-      after { Restforce.configuration.api_version = "26.0" }
+      before { Restforce.configuration.send("api_version=", "31.0") }
+      after { Restforce.configuration.send("api_version=", "26.0") }
 
       context 'with mashify middleware' do
         before do
@@ -162,7 +162,7 @@ describe Restforce::Concerns::API do
     end
 
     context "with unsupported api_version" do
-      before { Restforce.configuration.api_version = "26.0" }
+      before { Restforce.configuration.send("api_version=", "26.0") }
 
       subject { lambda { client.query_all(soql) } }
       it { should raise_error Restforce::UnsupportedError, "query_all requires Api version 29.0 or later" }


### PR DESCRIPTION
I stumbled across a new surprise feature of the Salesforce rest api.  The query endpoint doesn't return
1. Deleted records (even those still in the soft-deleted or recycle bin state.  
2. Archived records (tasks and events are archived automatically by Salesforce, based on some very complex rules)

according to http://www.salesforce.com/us/developer/docs/api_rest/index_Left.htm#CSHID=resources_queryall.htm|StartTopic=Content%2Fresources_queryall.htm|SkinName=webhelp

the QueryALL rest endpoint is available in api version 29.0 or later.  This will give us both soft-deleted and archived records. I opted to add a query_all method on concerns/api, so the existing behavior for query would not change.

