### PR TITLE
Add authentication_wrapper

### DIFF
--- a/lib/restforce/concerns/base.rb
+++ b/lib/restforce/concerns/base.rb
@@ -42,6 +42,9 @@ module Restforce
       #
       #        :authentication_callback
       #                                - A Proc that is called with the response body after a successful authentication.
+      #        :authentication_wrapper - A callable that wraps around the authentication action.
+      #                                  It is expected to call the passed block to run the authentication.
+      #                                  Be sure to return the value of the called block.
       def initialize(opts = {})
         raise ArgumentError, 'Please specify a hash of options' unless opts.is_a?(Hash)
         @options = Hash[Restforce.configuration.options.map { |option| [option, Restforce.configuration.send(option)] }]

--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -132,6 +132,11 @@ module Restforce
     # A Proc that is called with the response body after a successful authentication.
     option :authentication_callback
 
+    # A callable that wraps around the authentication action.
+    # It is expected to call the passed block to run the authentication.
+    # Be sure to return the value of the called block.
+    option :authentication_wrapper
+
     def logger
       @logger ||= ::Logger.new STDOUT
     end

--- a/spec/unit/middleware/authentication_spec.rb
+++ b/spec/unit/middleware/authentication_spec.rb
@@ -8,8 +8,65 @@ describe Restforce::Middleware::Authentication do
   end
 
   describe '.authenticate!' do
-    subject { lambda { middleware.authenticate! }}
-    it      { should raise_error NotImplementedError }
+    context 'without params' do
+      it 'raises' do
+        expect { middleware.authenticate! }.to raise_error NotImplementedError
+      end
+    end
+
+    context 'with params' do
+      before { allow(middleware).to receive(:params).and_return({foo: :bar}) }
+
+      context 'with a successful reauth' do
+        let(:reauth_success_response) { fixture(:reauth_success_response) }
+        let(:mashed_reauth_success_response) { Restforce::Mash.new(JSON.parse(reauth_success_response)) }
+
+        before do
+          stub_request(:post, "https://login.salesforce.com/services/oauth2/token").
+            with(:body => {"foo"=>"bar"},
+                 :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.0'}).
+            to_return(:status => 200, :body => reauth_success_response, :headers => {'Content-Type' => 'application/json;charset=UTF-8'})
+        end
+
+        it 'returns the response body' do
+          expect(middleware.authenticate!).to eq mashed_reauth_success_response
+        end
+
+        context 'with an authentication wrapper' do
+          it 'calls the authentication wrapper' do
+            # Test setup happens here so both setup and expectation have access to wrapper_called
+            wrapper_called = false
+            auth_wrapper = ->(&block) { wrapper_called = true; block.call }
+            options.merge!(:authentication_wrapper => auth_wrapper)
+
+            middleware.authenticate!
+            expect(wrapper_called).to be_true
+          end
+
+          it 'returns the response body' do
+            auth_wrapper = ->(&block) { result = block.call; wrapper_called = true; result }
+            options.merge!(:authentication_wrapper => auth_wrapper)
+            expect(middleware.authenticate!).to eq mashed_reauth_success_response
+          end
+        end
+      end
+
+      context 'with a failed reauth' do
+        let(:refresh_error_response) { fixture(:refresh_error_response) }
+        let(:mashed_refresh_error_response) { Restforce::Mash.new(JSON.parse(refresh_error_response)) }
+
+        before do
+          stub_request(:post, "https://login.salesforce.com/services/oauth2/token").
+            with(:body => {"foo"=>"bar"},
+                 :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Faraday v0.9.0'}).
+            to_return(:status => 400, :body => refresh_error_response, :headers => {'Content-Type' => 'application/json;charset=UTF-8'})
+        end
+
+        it 'raises AuthenticationError' do
+          expect { middleware.authenticate! }.to raise_error Restforce::AuthenticationError
+        end
+      end
+    end
   end
 
   describe '.call' do


### PR DESCRIPTION
Adds support for an authentication wrapper that runs around the
authentication action.  The callable should call/yield to the passed
block to run the authentication.

Note: This PR requires ruby 2.0 or greater.  See discussion on #158 about ruby versions.