### PR TITLE
Instruct travis to test newer rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.2
-  - 1.9.3
   - 2.0.0
-  - 2.1.2
-  - jruby-18mode
-  - jruby-19mode
-  - ree
+  - 2.1.5
   - rbx-2
+  - jruby-head
 gemfile:
   - Gemfile.travis
 script: bundle exec rake


### PR DESCRIPTION
After starting a discussion in #158 about ruby versions I figured I should have a proper PR to continue that discussion.  The only thing I see here is that we lose jruby-19mode in favor of jruby-head.  I'm not a jruby user myself so I would be interested in hearing some opinions.