### PR TITLE
Allow blocks to pass through

### DIFF
--- a/lib/restforce.rb
+++ b/lib/restforce.rb
@@ -44,16 +44,16 @@ module Restforce
     # Alias for Restforce::Data::Client.new
     #
     # Shamelessly pulled from https://github.com/pengwynn/octokit/blob/master/lib/octokit.rb
-    def new(*args)
-      data(*args)
+    def new(*args, &block)
+      data(*args, &block)
     end
 
-    def data(*args)
-      Restforce::Data::Client.new(*args)
+    def data(*args, &block)
+      Restforce::Data::Client.new(*args, &block)
     end
 
-    def tooling(*args)
-      Restforce::Tooling::Client.new(*args)
+    def tooling(*args, &block)
+      Restforce::Tooling::Client.new(*args, &block)
     end
 
     # Helper for decoding signed requests.

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -96,4 +96,14 @@ describe Restforce do
       end
     end
   end
+
+  describe '.new' do
+    it 'calls its block' do
+      checker = double(:block_checker)
+      expect(checker).to receive(:check!).once
+      Restforce.new do |builder|
+        checker.check!
+      end
+    end
+  end
 end


### PR DESCRIPTION
`Restforce.new` was dropping block arguments when calling through to the
underlying `Data::Client`.