### PR TITLE
Add limits resource to api

### DIFF
--- a/lib/restforce.rb
+++ b/lib/restforce.rb
@@ -39,6 +39,7 @@ module Restforce
   Error               = Class.new(StandardError)
   AuthenticationError = Class.new(Error)
   UnauthorizedError   = Class.new(Error)
+  APIVersionError     = Class.new(Error)
 
   class << self
     # Alias for Restforce::Data::Client.new

--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -55,6 +55,14 @@ module Restforce
         describe.collect { |sobject| sobject['name'] }
       end
 
+      # Public: Get info about limits in the connected organization
+      # Returns an Array of String names for each SObject.
+      def limits
+        version_guard(29.0) do
+          api_get("limits").body
+        end
+      end
+
       # Public: Returns a detailed describe result for the specified sobject
       #
       # sobject - Stringish name of the sobject (default: nil).
@@ -325,7 +333,7 @@ module Restforce
       def select(sobject, id, select, field=nil)
         path = field ? "sobjects/#{sobject}/#{field}/#{id}" : "sobjects/#{sobject}/#{id}"
         path << "?fields=#{select.join(",")}" if select && select.any?
-        
+
         api_get(path).body
       end
 
@@ -345,6 +353,14 @@ module Restforce
       # Internal: Errors that should be rescued from in non-bang methods
       def exceptions
         [Faraday::Error::ClientError]
+      end
+
+      def version_guard(version, &block)
+        if version.to_f <= options[:api_version].to_f
+          yield
+        else
+          raise APIVersionError, "(API Version: #{options[:api_version]}) You must have an api_version of at least #{version} to use this feature."
+        end
       end
 
     end

--- a/spec/unit/concerns/api_spec.rb
+++ b/spec/unit/concerns/api_spec.rb
@@ -29,6 +29,24 @@ describe Restforce::Concerns::API do
     it { should eq ['foo'] }
   end
 
+  describe '.limits' do
+    subject { client.limits }
+
+    it 'returns the limits for an organization' do
+      limits = double('limits')
+      limits.stub(:body).and_return({})
+      client.should_receive(:api_get).with("limits").and_return(limits)
+      client.should_receive(:options).and_return({:api_version => "29.0"})
+      expect(client.limits).to eq({})
+    end
+
+    it "raises an exception if we aren't at version 29.0 or above" do
+      client.should_receive(:options).twice.and_return({:api_version => "24.0"})
+      expect {client.limits}.to raise_error(Restforce::APIVersionError)
+    end
+
+  end
+
   describe '.describe' do
     subject(:describe) { client.describe }
 


### PR DESCRIPTION
Adds the **limits** resource to api.rb.
This also adds a `version_guard` method that will raise an exception if you aren't connected at a version that supports this feature. It was written in a way that can be re-used for other resources.

https://www.salesforce.com/us/developer/docs/api_rest/Content/dome_limits.htm