### PR TITLE
Add query explain method to api

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ account.destroy
 # => true
 ```
 
+### explain
+
+`explain` takes the same parameters as `query` and returns a query plan in JSON format.
+For the nitty-gritty details on the response meanings visit the
+[Salesforce Query Explain](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_query_explain.htm) page.
+
+```ruby
+accounts = client.explain("select Id, Something__c from Account where Id = 'someid'")
+# => #<Restforce::Mash >
+```
+
 ### find
 
 ```ruby
@@ -274,6 +285,21 @@ client.picklist_values('Automobile__c', 'Model__c', :valid_for => 'Honda')
 client.user_info
 # => #<Restforce::Mash active=true display_name="Chatty Sassy" email="user@example.com" ... >
 ```
+
+### limits
+`limits` returns the API limits for the currently connected Organization. This includes information
+such as **Daily API calls** and **Daily Bulk API calls**. More information can be found on the
+[Salesforce Limits](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_limits.htm) page.
+
+```ruby
+# Get the current limit info
+limits = client.limits
+# => #<Restforce::Mash >
+
+limits["DailyApiRequests"]
+# => {"Max"=>15000, "Remaining"=>14746}
+```
+
 
 * * *
 

--- a/lib/restforce.rb
+++ b/lib/restforce.rb
@@ -39,6 +39,7 @@ module Restforce
   Error               = Class.new(StandardError)
   AuthenticationError = Class.new(Error)
   UnauthorizedError   = Class.new(Error)
+  APIVersionError     = Class.new(Error)
 
   class << self
     # Alias for Restforce::Data::Client.new

--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -55,6 +55,14 @@ module Restforce
         describe.collect { |sobject| sobject['name'] }
       end
 
+      # Public: Get info about limits in the connected organization
+      # Returns an Array of String names for each SObject.
+      def limits
+        version_guard(29.0) do
+          api_get("limits").body
+        end
+      end
+
       # Public: Returns a detailed describe result for the specified sobject
       #
       # sobject - Stringish name of the sobject (default: nil).
@@ -325,7 +333,7 @@ module Restforce
       def select(sobject, id, select, field=nil)
         path = field ? "sobjects/#{sobject}/#{field}/#{id}" : "sobjects/#{sobject}/#{id}"
         path << "?fields=#{select.join(",")}" if select && select.any?
-        
+
         api_get(path).body
       end
 
@@ -345,6 +353,14 @@ module Restforce
       # Internal: Errors that should be rescued from in non-bang methods
       def exceptions
         [Faraday::Error::ClientError]
+      end
+
+      def version_guard(version, &block)
+        if version.to_f <= options[:api_version].to_f
+          yield
+        else
+          raise APIVersionError, "(API Version: #{options[:api_version]}) You must have an api_version of at least #{version} to use this feature."
+        end
       end
 
     end

--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -139,6 +139,22 @@ module Restforce
         mashify? ? response.body : response.body['records']
       end
 
+      # Public: Explain a SOQL query execution plan
+      #
+      # soql - A SOQL expression.
+      #
+      # Examples
+      #
+      #   # Find the names of all Accounts
+      #   client.explain('select Name from Account')
+      # Returns a Hash in the form {:plans => [Array of plan data]}
+      # See: https://www.salesforce.com/us/developer/docs/api_rest/Content/dome_query_explain.htm
+      def explain(soql)
+        version_guard(30.0) do
+          api_get("query", :explain => soql).body
+        end
+      end
+
       # Public: Perform a SOSL search
       #
       # sosl - A SOSL expression.

--- a/spec/unit/concerns/api_spec.rb
+++ b/spec/unit/concerns/api_spec.rb
@@ -29,6 +29,24 @@ describe Restforce::Concerns::API do
     it { should eq ['foo'] }
   end
 
+  describe '.limits' do
+    subject { client.limits }
+
+    it 'returns the limits for an organization' do
+      limits = double('limits')
+      limits.stub(:body).and_return({})
+      client.should_receive(:api_get).with("limits").and_return(limits)
+      client.should_receive(:options).and_return({:api_version => "29.0"})
+      expect(client.limits).to eq({})
+    end
+
+    it "raises an exception if we aren't at version 29.0 or above" do
+      client.should_receive(:options).twice.and_return({:api_version => "24.0"})
+      expect {client.limits}.to raise_error(Restforce::APIVersionError)
+    end
+
+  end
+
   describe '.describe' do
     subject(:describe) { client.describe }
 

--- a/spec/unit/concerns/api_spec.rb
+++ b/spec/unit/concerns/api_spec.rb
@@ -140,6 +140,26 @@ describe Restforce::Concerns::API do
     end
   end
 
+  describe '.explain' do
+    let(:soql)        { 'Select Id from Account' }
+    subject(:results) { client.explain(soql) }
+
+    it "returns an execute plan for this SOQL" do
+      plans = double("plans")
+      plans.stub(:body).and_return({"plans" => []})
+      client.should_receive(:api_get).
+        with("query", :explain => soql).
+        and_return(plans)
+      client.should_receive(:options).and_return({:api_version => "30.0"})
+      expect(results).to eq({"plans" => []})
+    end
+
+    it "raises an exception if we aren't at version 30.0 or above" do
+      client.should_receive(:options).twice.and_return({:api_version => "24.0"})
+      expect {results}.to raise_error(Restforce::APIVersionError)
+    end
+  end
+
   describe '.search' do
     let(:sosl)        { 'FIND {bar}' }
     subject(:results) { client.search(sosl) }


### PR DESCRIPTION
This builds on pull request #177 so you'll see some duplication between that request and this one. The reason is because I needed the `version_guard` method.

https://www.salesforce.com/us/developer/docs/api_rest/Content/dome_query_explain.htm