### PR TITLE
Stop Restforce::Concerns::API#update! and Restforce::Concerns::API#upsert! mutating provided attributes

### DIFF
--- a/spec/unit/concerns/api_spec.rb
+++ b/spec/unit/concerns/api_spec.rb
@@ -177,11 +177,11 @@ describe Restforce::Concerns::API do
     subject(:result) { client.update!(sobject, attrs) }
 
     context 'when the id field is present' do
-      let(:attrs) { { :id => '1234' } }
+      let(:attrs) { { :id => '1234', :StageName => "Call Scheduled" } }
 
       it 'sends an HTTP PATCH, and returns true' do
         client.should_receive(:api_patch).
-          with('sobjects/Whizbang/1234', attrs)
+          with('sobjects/Whizbang/1234', { :StageName => "Call Scheduled" })
         expect(result).to be_true
       end
     end


### PR DESCRIPTION
The use of `Hash#delete` in `Restforce::Concerns::API#update!` and `Restforce::Concerns::API#upsert!` means that the `attrs` passed into the Restforce client are mutated. It's generally not desirable for an external dependency like this gem to modify provided data in-memory.

This updates those methods to pull out the desired ID to update or upsert in a non-destructive way.