### PR TITLE
Add a note about client object thread safety to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ If you're using the gem to interact with a single org (maybe you're building som
 salesforce integration internally?) then you should use the username/password
 authentication method.
 
+It is also important to note that the client object should not be reused across different threads, otherwise you may encounter thread-safety issues.
+
 #### OAuth token authentication
 
 ```ruby


### PR DESCRIPTION
I had an issue trying to use Restforce with Sidekiq in a rails application. Turns out that reusing the client object causes a whole bunch of strange issues to manifest. I'm not positive if Restforce stores some state on the client or if it's an issue with Net::HTTP but I figured a note in the README would be nice to possibly help out other devs.