### PR TITLE
Test against latest Ruby teeny versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.2
-  - 2.2.0
+  - 2.1
+  - 2.2
   - jruby-19mode
   - rbx-2
 gemfile:


### PR DESCRIPTION
See https://www.ruby-lang.org/en/news/2013/12/21/ruby-version-policy-changes-with-2-1-0/
for more details.

Alternative to https://github.com/ejholmes/restforce/pull/163.