### PR TITLE
Add #recent method to the client, reimplementing #150

### DIFF
--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -338,6 +338,21 @@ module Restforce
         api_get(path).body
       end
 
+      # Public: Finds recently viewed items for the logged-in user.
+      #
+      # limit - An optional limit that specifies the maximum number of records to be
+      #         returned.
+      #         If this parameter is not specified, the default maximum number of records
+      #         returned is the maximum number of entries in RecentlyViewed, which is 200
+      #         records per object.
+      #
+      # Returns an array of the recently viewed Restforce::SObject records.
+      def recent(limit = nil)
+        path = limit ? "recent?limit=#{limit}" : "recent"
+
+        api_get(path).body
+      end
+
       private
 
       # Internal: Returns a path to an api endpoint

--- a/spec/unit/concerns/api_spec.rb
+++ b/spec/unit/concerns/api_spec.rb
@@ -308,4 +308,25 @@ describe Restforce::Concerns::API do
       end
     end
   end
+
+  describe "#recent" do
+    let(:limit) { nil }
+    subject(:result) { client.recent(limit) }
+
+    context "given no limit is specified" do
+      it "returns the most recently viewed items for the logged-in user" do
+        client.should_receive(:api_get).with('recent').and_return(response)
+        expect(result).to eq response.body
+      end
+    end
+
+    context "given a limit is specified" do
+      let(:limit) { 10 }
+
+      it "returns up to the limit specified results" do
+        client.should_receive(:api_get).with('recent?limit=10').and_return(response)
+        expect(result).to eq response.body
+      end
+    end
+  end
 end


### PR DESCRIPTION
New mergeable version of #150, with slightly improved specs and formatting.