### PR TITLE
Change proxy environment variable from PROXY_URI to SALESFORCE_PROXY_URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ client = Restforce.new
 
 ### Proxy Support
 
-You can specify a HTTP proxy using the `proxy_uri` option, as follows, or by setting the `PROXY_URI` environment variable:
+You can specify a HTTP proxy using the `proxy_uri` option, as follows, or by setting the `SALESFORCE_PROXY_URI` environment variable:
 
 ```ruby
 client = Restforce.new :username => 'foo',

--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -134,7 +134,7 @@ module Restforce
     option :adapter, default: lambda { Faraday.default_adapter }
 
     # TODO: Rename this to `SALESFORCE_PROXY_URI` in next major version
-    option :proxy_uri, default: lambda { ENV['PROXY_URI'] }
+    option :proxy_uri, default: lambda { ENV['SALESFORCE_PROXY_URI'] }
 
     # A Proc that is called with the response body after a successful authentication.
     option :authentication_callback

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -38,7 +38,7 @@ describe Restforce do
           'SALESFORCE_SECURITY_TOKEN' => 'foobar',
           'SALESFORCE_CLIENT_ID'      => 'client id',
           'SALESFORCE_CLIENT_SECRET'  => 'client secret',
-          'PROXY_URI'                 => 'proxy',
+          'SALESFORCE_PROXY_URI'      => 'proxy',
           'SALESFORCE_HOST'           => 'test.host.com' }.
         each { |var, value| ENV.stub(:[]).with(var).and_return(value) }
       end


### PR DESCRIPTION
Probably not a good idea to use such a generic environment variable, and doesn't follow the pattern in the rest of the gem.

This will go out as part of 2.1.0.