### PR TITLE
Respect Faraday adapter option in authentication

### DIFF
--- a/lib/restforce/middleware/authentication.rb
+++ b/lib/restforce/middleware/authentication.rb
@@ -52,7 +52,7 @@ module Restforce
                     Restforce.configuration.logger,
                     @options if Restforce.log?
 
-        builder.adapter Faraday.default_adapter
+        builder.adapter @options[:adapter]
       end
     end
 

--- a/spec/unit/middleware/authentication/password_spec.rb
+++ b/spec/unit/middleware/authentication/password_spec.rb
@@ -7,7 +7,8 @@ describe Restforce::Middleware::Authentication::Password do
       password: 'bar',
       security_token: 'security_token',
       client_id: 'client_id',
-      client_secret: 'client_secret' }
+      client_secret: 'client_secret',
+      adapter: :net_http }
   end
 
   it_behaves_like 'authentication middleware' do

--- a/spec/unit/middleware/authentication/token_spec.rb
+++ b/spec/unit/middleware/authentication/token_spec.rb
@@ -5,7 +5,8 @@ describe Restforce::Middleware::Authentication::Token do
     { host: 'login.salesforce.com',
       refresh_token: 'refresh_token',
       client_id: 'client_id',
-      client_secret: 'client_secret' }
+      client_secret: 'client_secret',
+      adapter: :net_http }
   end
 
   it_behaves_like 'authentication middleware' do

--- a/spec/unit/middleware/authentication_spec.rb
+++ b/spec/unit/middleware/authentication_spec.rb
@@ -4,7 +4,8 @@ describe Restforce::Middleware::Authentication do
   let(:options) do
     { host: 'login.salesforce.com',
       proxy_uri: 'https://not-a-real-site.com',
-      authentication_retries: retries }
+      authentication_retries: retries,
+      adapter: :net_http }
   end
 
   describe '.authenticate!' do
@@ -67,6 +68,16 @@ describe Restforce::Middleware::Authentication do
         its(:handlers) {
           should include FaradayMiddleware::ParseJson,
                          Restforce::Middleware::Logger, Faraday::Adapter::NetHttp
+        }
+      end
+
+      context 'with specified adapter' do
+        before do
+          options[:adapter] = :typhoeus
+        end
+
+        its(:handlers) {
+          should include FaradayMiddleware::ParseJson, Faraday::Adapter::Typhoeus
         }
       end
     end


### PR DESCRIPTION
There is another Faraday connection created in the authentication middleware, and this connection didn’t respect the adapter option, which meant that Net::HTTP was always used for that connection.