### PR TITLE
Update Restforce Streaming Documentation to indicate `faye` version

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,8 @@ created/updated.
 
 _See also: [Force.com Streaming API docs](http://www.salesforce.com/us/developer/docs/api_streaming/index.htm)_
 
+*Note:* Restforce's streaming implementation is known to be compatible with version `0.8.9` of the faye gem.
+
 * * *
 
 ### Caching


### PR DESCRIPTION
The existing documentation for Restforce's Streaming support
did not mention the version of the `faye` gem to be used.

This is a small change to the documentation to indicate that
version `0.8.9` is that known working version of faye.

Resolves https://github.com/ejholmes/restforce/issues/194