### PR TITLE
Fix caching spec

### DIFF
--- a/lib/restforce/middleware/caching.rb
+++ b/lib/restforce/middleware/caching.rb
@@ -18,7 +18,7 @@ module Restforce
     end
 
     def use_cache?
-      !@options.key?(:use_cache) || @options[:use_cache]
+      @options.fetch(:use_cache, true)
     end
   end
 end

--- a/spec/support/mock_cache.rb
+++ b/spec/support/mock_cache.rb
@@ -3,6 +3,14 @@ class MockCache
     @storage = {}
   end
 
+  def read(key)
+    @storage[key]
+  end
+
+  def write(key, value)
+    @storage[key] = value
+  end
+
   def fetch(key, &block)
     @storage[key] ||= block.call
   end


### PR DESCRIPTION
Faraday middleware has been updated and uses #read instead of #fetch.
MockCache has been updated to implement #read. #fetch remains in case we
want to support an older version of faraday_middleware.

See faraday_middleware commit:
https://github.com/lostisland/faraday_middleware/commit/3f559c18ee82701d8a1d04faf2bfd92d180b737b#diff-32d8ad0f070291407b5ceb8e788fb40fR47

Current failing travis build: https://travis-ci.org/ejholmes/restforce/jobs/81812544