### PR TITLE
Fix raise error parsing

### DIFF
--- a/lib/restforce/concerns/connection.rb
+++ b/lib/restforce/concerns/connection.rb
@@ -38,14 +38,14 @@ module Restforce
           builder.use      Restforce::Middleware::Authorization, self, options
           # Ensures the instance url is set.
           builder.use      Restforce::Middleware::InstanceURL, self, options
-          # Parses returned JSON response into a hash.
-          builder.response :json, content_type: /\bjson$/
           # Caches GET requests.
           builder.use      Restforce::Middleware::Caching, cache, options if cache
           # Follows 30x redirects.
           builder.use      FaradayMiddleware::FollowRedirects
           # Raises errors for 40x responses.
           builder.use      Restforce::Middleware::RaiseError
+          # Parses returned JSON response into a hash.
+          builder.response :json, content_type: /\bjson$/
           # Log request/responses
           builder.use      Restforce::Middleware::Logger,
                            Restforce.configuration.logger,

--- a/lib/restforce/middleware/caching.rb
+++ b/lib/restforce/middleware/caching.rb
@@ -18,7 +18,7 @@ module Restforce
     end
 
     def use_cache?
-      !@options.key?(:use_cache) || @options[:use_cache]
+      @options.fetch(:use_cache, true)
     end
   end
 end

--- a/lib/restforce/middleware/raise_error.rb
+++ b/lib/restforce/middleware/raise_error.rb
@@ -16,11 +16,18 @@ module Restforce
     end
 
     def message
-      "#{body.first['errorCode']}: #{body.first['message']}"
+      "#{body['errorCode']}: #{body['message']}"
     end
 
     def body
-      JSON.parse(@env[:body])
+      @body = (@env[:body].respond_to?(:first) ? @env[:body].first : @env[:body])
+
+      case @body
+      when Hash
+        @body
+      else
+        { 'errorCode' => '(error code missing)', 'message' => @body }
+      end
     end
 
     def response_values

--- a/spec/integration/abstract_client_spec.rb
+++ b/spec/integration/abstract_client_spec.rb
@@ -100,13 +100,22 @@ shared_examples_for Restforce::AbstractClient do
                status: 404,
                fixture: 'sobject/delete_error_response'
 
+      let(:error) do
+        JSON.parse(fixture('sobject/delete_error_response'))
+      end
+
       subject do
         lambda do
           client.update!('Account', Id: '001D000000INjVe', Name: 'Foobar')
         end
       end
 
-      it { should raise_error Faraday::Error::ResourceNotFound }
+      it {
+        should raise_error(
+          Faraday::Error::ResourceNotFound,
+          "#{error.first['errorCode']}: #{error.first['message']}"
+        )
+      }
     end
   end
 

--- a/spec/support/mock_cache.rb
+++ b/spec/support/mock_cache.rb
@@ -3,6 +3,14 @@ class MockCache
     @storage = {}
   end
 
+  def read(key)
+    @storage[key]
+  end
+
+  def write(key, value)
+    @storage[key] = value
+  end
+
   def fetch(key, &block)
     @storage[key] ||= block.call
   end

--- a/spec/unit/middleware/raise_error_spec.rb
+++ b/spec/unit/middleware/raise_error_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Restforce::Middleware::RaiseError do
-  let(:body)       { fixture('sobject/query_error_response') }
+  let(:body)       { JSON.parse(fixture('sobject/query_error_response')) }
   let(:env)        { { status: status, body: body } }
   let(:middleware) { described_class.new app }
 
@@ -37,11 +37,20 @@ describe Restforce::Middleware::RaiseError do
 
     context 'when the status code is 413' do
       let(:status) { 413 }
-      let(:body) { '' } # Zero length response
 
       it "raises an error" do
         expect { on_complete }.to raise_error Faraday::Error::ClientError,
                                               'HTTP 413 - Request Entity Too Large'
+      end
+    end
+
+    context 'when status is 400+ and body is a string' do
+      let(:body)   { 'An error occured' }
+      let(:status) { 404 }
+
+      it 'raises an error with a non-existing error code' do
+        expect { on_complete }.to raise_error Faraday::Error::ClientError,
+                                              "(error code missing): #{body}"
       end
     end
   end


### PR DESCRIPTION
This fixes #208. This branch is on top of `kouno:fix-cache-read` to see all tests pass.