### PR TITLE
Check for type instead of using duck typing

### DIFF
--- a/lib/restforce/middleware/raise_error.rb
+++ b/lib/restforce/middleware/raise_error.rb
@@ -20,7 +20,7 @@ module Restforce
     end
 
     def body
-      @body = (@env[:body].respond_to?(:first) ? @env[:body].first : @env[:body])
+      @body = (@env[:body].is_a?(Array) ? @env[:body].first : @env[:body])
 
       case @body
       when Hash


### PR DESCRIPTION
When using ActiveSupport, the String class actually defines #first and
this would cause the body to be truncated to the first character.

The current tests are valid and still pass with this fix, but the
failing behavior only shows if you have active support included in your
project.

@timrogers sorry about that one. :see_no_evil: 