### PR TITLE
Raise a server error when authentication fails

### DIFF
--- a/lib/restforce.rb
+++ b/lib/restforce.rb
@@ -37,6 +37,7 @@ module Restforce
   end
 
   Error               = Class.new(StandardError)
+  ServerError         = Class.new(Error)
   AuthenticationError = Class.new(Error)
   UnauthorizedError   = Class.new(Error)
   APIVersionError     = Class.new(Error)

--- a/lib/restforce/middleware/authentication.rb
+++ b/lib/restforce/middleware/authentication.rb
@@ -22,7 +22,9 @@ module Restforce
         req.body = encode_www_form(params)
       end
 
-      if response.status != 200
+      if response.status >= 500
+        raise Restforce::ServerError, error_message(response)
+      elsif response.status != 200
         raise Restforce::AuthenticationError, error_message(response)
       end
 


### PR DESCRIPTION
Introduces a new error class, `ServerError`, which is raised when authentication fails with a 5xx code.