### PR TITLE
Handle 300 errors triggered by an upsert where the external ID matches multiple records

### DIFF
--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -315,7 +315,8 @@ module Restforce
       #
       # Returns true if the record was found and updated.
       # Returns the Id of the newly created record if the record was created.
-      # Returns false if something bad happens.
+      # Returns false if something bad happens (for example if the external ID matches
+      # multiple resources).
       def upsert(*args)
         upsert!(*args)
       rescue *exceptions
@@ -335,7 +336,9 @@ module Restforce
       #
       # Returns true if the record was found and updated.
       # Returns the Id of the newly created record if the record was created.
-      # Raises an exception if an error is returned from Salesforce.
+      # Raises an exception if an error is returned from Salesforce, including the 300
+      # error returned if the external ID provided matches multiple records (in which
+      # case the conflicting IDs can be found by looking at the response on the error)
       def upsert!(sobject, field, attrs)
         external_id = attrs.
           fetch(attrs.keys.find { |k, v| k.to_s.downcase == field.to_s.downcase }, nil)

--- a/lib/restforce/middleware/raise_error.rb
+++ b/lib/restforce/middleware/raise_error.rb
@@ -3,10 +3,14 @@ module Restforce
     def on_complete(env)
       @env = env
       case env[:status]
-      when 404
-        raise Faraday::Error::ResourceNotFound, message
+      when 300
+        raise Faraday::Error::ClientError.new("300: The external ID provided matches " \
+                                              "more than one record",
+                                              response_values)
       when 401
         raise Restforce::UnauthorizedError, message
+      when 404
+        raise Faraday::Error::ResourceNotFound, message
       when 413
         raise Faraday::Error::ClientError.new("HTTP 413 - Request Entity Too Large",
                                               response_values)

--- a/spec/unit/middleware/raise_error_spec.rb
+++ b/spec/unit/middleware/raise_error_spec.rb
@@ -17,6 +17,15 @@ describe Restforce::Middleware::RaiseError do
       end
     end
 
+    context 'when the status code is 300' do
+      let(:status) { 300 }
+
+      it "raises an error" do
+        expect { on_complete }.to raise_error Faraday::Error::ClientError,
+                                              /300: The external ID provided/
+      end
+    end
+
     context 'when the status code is 400' do
       let(:status) { 400 }
 


### PR DESCRIPTION
If you try to insert or update (upsert) a record using an external ID (see <https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_upsert.htm>) and the external ID provided is not unique, Salesforce returns a 300 response with a list of matching records as an array. This 300 behaviour can also be expected elsewhere in the API (<https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/errorcodes.htm>).

This allows us to handle that response and raise an exception, as you'd expect, and provides access to the list of matching IDs returned, since once can access the response body of a `Faraday::ClientError` with `#response` (<http://www.rubydoc.info/github/lostisland/faraday/Faraday/ClientError>).

Fixes #224.