### PR TITLE
Improve the consistency of `Faraday::Error::ClientError`s raised by the `RaiseError` middleware

### DIFF
--- a/lib/restforce/middleware/raise_error.rb
+++ b/lib/restforce/middleware/raise_error.rb
@@ -12,7 +12,7 @@ module Restforce
       when 404
         raise Faraday::Error::ResourceNotFound, message
       when 413
-        raise Faraday::Error::ClientError.new("HTTP 413 - Request Entity Too Large",
+        raise Faraday::Error::ClientError.new("413: Request Entity Too Large",
                                               response_values)
       when 400...600
         raise Faraday::Error::ClientError.new(message, response_values)

--- a/spec/unit/middleware/raise_error_spec.rb
+++ b/spec/unit/middleware/raise_error_spec.rb
@@ -49,7 +49,7 @@ describe Restforce::Middleware::RaiseError do
 
       it "raises an error" do
         expect { on_complete }.to raise_error Faraday::Error::ClientError,
-                                              'HTTP 413 - Request Entity Too Large'
+                                              '413: Request Entity Too Large'
       end
     end
 


### PR DESCRIPTION
For consistency with the 300 and 400-600 `Faraday::Error::ClientError`s we raise in `Restforce::Middleware::RaiseError`, an HTTP 413 response should raise an error with a message in the same format ("#{http_status_code}: #{description_of_error}").

This is potentially a non-backwards-compatible change, in the unlikely event that people are doing some kind of special rescuing of this error.