### PR TITLE
encode external id for upsert! to get rid of error with multibytes external id

### DIFF
--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -395,7 +395,7 @@ module Restforce
       #
       # Returns the Restforce::SObject sobject record.
       def find(sobject, id, field = nil)
-        url = field ? "sobjects/#{sobject}/#{field}/#{id}" : "sobjects/#{sobject}/#{id}"
+        url = field ? "sobjects/#{sobject}/#{field}/#{URI.encode(id)}" : "sobjects/#{sobject}/#{id}"
         api_get(url).body
       end
 
@@ -409,7 +409,7 @@ module Restforce
       # field   - External ID field to use (default: nil).
       #
       def select(sobject, id, select, field = nil)
-        path = field ? "sobjects/#{sobject}/#{field}/#{id}" : "sobjects/#{sobject}/#{id}"
+        path = field ? "sobjects/#{sobject}/#{field}/#{URI.encode(id)}" : "sobjects/#{sobject}/#{id}"
         path << "?fields=#{select.join(',')}" if select && select.any?
 
         api_get(path).body

--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -395,7 +395,11 @@ module Restforce
       #
       # Returns the Restforce::SObject sobject record.
       def find(sobject, id, field = nil)
-        url = field ? "sobjects/#{sobject}/#{field}/#{URI.encode(id)}" : "sobjects/#{sobject}/#{id}"
+        if field
+          url = "sobjects/#{sobject}/#{field}/#{URI.encode(id)}"
+        else
+          url = "sobjects/#{sobject}/#{id}"
+        end
         api_get(url).body
       end
 
@@ -409,7 +413,11 @@ module Restforce
       # field   - External ID field to use (default: nil).
       #
       def select(sobject, id, select, field = nil)
-        path = field ? "sobjects/#{sobject}/#{field}/#{URI.encode(id)}" : "sobjects/#{sobject}/#{id}"
+        if field
+          path = "sobjects/#{sobject}/#{field}/#{URI.encode(id)}"
+        else
+          path = "sobjects/#{sobject}/#{id}"
+        end
         path << "?fields=#{select.join(',')}" if select && select.any?
 
         api_get(path).body

--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -1,3 +1,4 @@
+require 'uri'
 require 'restforce/concerns/verbs'
 
 module Restforce
@@ -344,7 +345,7 @@ module Restforce
           fetch(attrs.keys.find { |k, v| k.to_s.downcase == field.to_s.downcase }, nil)
         attrs_without_field = attrs.
           reject { |k, v| k.to_s.downcase == field.to_s.downcase }
-        response = api_patch "sobjects/#{sobject}/#{field}/#{external_id}",
+        response = api_patch "sobjects/#{sobject}/#{field}/#{URI.encode(external_id)}",
                              attrs_without_field
 
         (response.body && response.body['id']) ? response.body['id'] : true

--- a/spec/unit/concerns/api_spec.rb
+++ b/spec/unit/concerns/api_spec.rb
@@ -328,6 +328,23 @@ describe Restforce::Concerns::API do
     end
   end
 
+  describe '.upsert! with multi bytes character' do
+    let(:sobject)    { 'Whizbang' }
+    let(:field)      { :External_ID__c }
+    let(:attrs)      { { 'External_ID__c' => "\u{3042}" } }
+    subject(:result) { client.upsert!(sobject, field, attrs) }
+
+    context 'when the record is found and updated' do
+      it 'returns true' do
+        response.body.stub :[]
+        client.should_receive(:api_patch).
+          with('sobjects/Whizbang/External_ID__c/%E3%81%82', {}).
+          and_return(response)
+        expect(result).to be_true
+      end
+    end
+  end
+
   describe '.destroy!' do
     let(:id)         { '1234' }
     let(:sobject)    { 'Whizbang' }

--- a/spec/unit/concerns/api_spec.rb
+++ b/spec/unit/concerns/api_spec.rb
@@ -382,6 +382,17 @@ describe Restforce::Concerns::API do
         expect(result).to eq response.body
       end
     end
+
+    context 'when an external id which contains multibyte characters is specified' do
+      let(:field) { :External_ID__c }
+      let(:id)    { "\u{3042}" }
+      it 'returns the full representation of the object' do
+        client.should_receive(:api_get).
+          with('sobjects/Whizbang/External_ID__c/%E3%81%82').
+          and_return(response)
+        expect(result).to eq response.body
+      end
+    end
   end
 
   describe '.select' do
@@ -426,6 +437,28 @@ describe Restforce::Concerns::API do
         it 'returns the full representation of the object' do
           client.should_receive(:api_get).
             with('sobjects/Whizbang/External_ID__c/1234?fields=External_ID__c').
+            and_return(response)
+          expect(result).to eq response.body
+        end
+      end
+    end
+
+    context 'when an external id which contains multibyte characters is specified' do
+      let(:field) { :External_ID__c }
+      let(:id) { "\u{3042}" }
+      context 'when no select list is specified' do
+        it 'returns the full representation of the object' do
+          client.should_receive(:api_get).
+            with('sobjects/Whizbang/External_ID__c/%E3%81%82').
+            and_return(response)
+          expect(result).to eq response.body
+        end
+      end
+      context 'when select list is specified' do
+        let(:select) { [:External_ID__c] }
+        it 'returns the full representation of the object' do
+          client.should_receive(:api_get).
+            with('sobjects/Whizbang/External_ID__c/%E3%81%82?fields=External_ID__c').
             and_return(response)
           expect(result).to eq response.body
         end


### PR DESCRIPTION
When I pass strings contains multibytes characters as external ID to Restforce::Concerns::API#upsert!, it raise `URI::InvalidURIError:URI must be ascii only` exception.
To get rid the failure, URI encode the external ID when embeded it into request path.
