### PR TITLE
Add support for get_deleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ client.get_updated('Account', Time.local(2015,8,18), Time.local(2015,8,19))
 Retrieves the list of IDs and time of deletion for records that have been deleted within the given timespan for the specified object
 
 ```ruby
-# Get the ids of all accounts which have been deleted in the last day
+# Get the list of accounts which have been deleted in the last day
 client.get_deleted('Account', Time.local(2015,8,18), Time.local(2015,8,19))
 # => { ... }
 ```

--- a/README.md
+++ b/README.md
@@ -380,6 +380,18 @@ client.get_updated('Account', Time.local(2015,8,18), Time.local(2015,8,19))
 
 * * *
 
+### get_deleted
+
+Retrieves the list of IDs and time of deletion for records that have been deleted within the given timespan for the specified object
+
+```ruby
+# Get the ids of all accounts which have been deleted in the last day
+client.get_deleted('Account', Time.local(2015,8,18), Time.local(2015,8,19))
+# => { ... }
+```
+
+* * *
+
 ### authenticate!
 
 Performs an authentication and returns the response. In general, calling this

--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -84,6 +84,26 @@ module Restforce
         api_get(url).body
       end
 
+      # Public: Gets the IDs of sobjects of type [sobject]
+      # which have been deleted between startDateTime and endDateTime.
+      #
+      # Examples
+      #
+      #   # get deleted sobject Whizbangs between yesterday and today
+      #   startDate = Time.new(2002, 10, 31, 2, 2, 2, "+02:00")
+      #   endDate = Time.new(2002, 11, 1, 2, 2, 2, "+02:00")
+      #   client.get_deleted('Whizbang', startDate, endDate)
+      #
+      # Returns a Restforce::Collection if Restforce.configuration.mashify is true.
+      # Returns an Array of Hash for each record in the result if
+      # Restforce.configuration.mashify is false.
+      def get_deleted(sobject, start_time, end_time)
+        start_time = start_time.utc.iso8601
+        end_time = end_time.utc.iso8601
+        url = "/sobjects/#{sobject}/deleted/?start=#{start_time}&end=#{end_time}"
+        api_get(url).body
+      end
+
       # Public: Returns a detailed describe result for the specified sobject
       #
       # sobject - Stringish name of the sobject (default: nil).

--- a/spec/fixtures/sobject/get_deleted_success_response.json
+++ b/spec/fixtures/sobject/get_deleted_success_response.json
@@ -1,0 +1,11 @@
+{
+    "deletedRecords" :
+    [
+        {
+            "id" : "a00D0000008pQRAIA2",
+            "deletedDate" : "2013-05-07T22:07:19.000+0000"
+        }
+    ],
+    "earliestDateAvailable" : "2013-05-03T15:57:00.000+0000",
+    "latestDateCovered" : "2013-05-08T21:20:00.000+0000"
+}

--- a/spec/integration/abstract_client_spec.rb
+++ b/spec/integration/abstract_client_spec.rb
@@ -45,6 +45,17 @@ shared_examples_for Restforce::AbstractClient do
     it { should be_an Enumerable }
   end
 
+  describe '.get_deleted' do
+    let(:start_date) { Time.new(2015, 8, 17, 0, 0, 0, "+02:00")  }
+    let(:end_date) { Time.new(2016, 8, 19, 0, 0, 0, "+02:00") }
+    end_string = '2016-08-18T22:00:00Z'
+    start_string = '2015-08-16T22:00:00Z'
+    requests "sobjects/Whizbang/deleted/\\?end=#{end_string}&start=#{start_string}",
+             fixture: 'sobject/get_deleted_success_response'
+    subject { client.get_deleted('Whizbang', start_date, end_date) }
+    it { should be_an Enumerable }
+  end
+
   describe '.search' do
     requests 'search\?q=FIND%20%7Bbar%7D', fixture: 'sobject/search_success_response'
 

--- a/spec/unit/concerns/api_spec.rb
+++ b/spec/unit/concerns/api_spec.rb
@@ -35,6 +35,22 @@ describe Restforce::Concerns::API do
     end
   end
 
+  describe '.get_deleted' do
+    let(:start_date_time) { Time.new(2002, 10, 31, 2, 2, 2, "+02:00") }
+    let(:end_date_time) { Time.new(2003, 10, 31, 2, 2, 2, "+02:00") }
+    let(:sobject) { 'Whizbang' }
+    subject(:results) { client.get_deleted(sobject, start_date_time, end_date_time) }
+    it 'returns the body' do
+      start_string = '2002-10-31T00:02:02Z'
+      end_string = '2003-10-31T00:02:02Z'
+      url = "/sobjects/Whizbang/deleted/?start=#{start_string}&end=#{end_string}"
+      client.should_receive(:api_get).
+        with(url).
+        and_return(response)
+      expect(results).to eq response.body
+    end
+  end
+
   describe '.list_sobjects' do
     subject { client.list_sobjects }
 


### PR DESCRIPTION
Followed the pattern for `get_updated` and took the sample response from the [Salesforce developer docs](https://developer.salesforce.com/docs/atlas.en-us.202.0.api_rest.meta/api_rest/dome_get_deleted.htm)