### PR TITLE
set SF api version from env var

### DIFF
--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -88,7 +88,7 @@ module Restforce
       end
     end
 
-    option :api_version, default: '26.0'
+    option :api_version, default: lambda { ENV['SALESFORCE_API_VERSION'] || '26.0' }
 
     # The username to use during login.
     option :username, default: lambda { ENV['SALESFORCE_USERNAME'] }

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -7,6 +7,7 @@ describe Restforce do
     ENV['SALESFORCE_SECURITY_TOKEN'] = nil
     ENV['SALESFORCE_CLIENT_ID']      = nil
     ENV['SALESFORCE_CLIENT_SECRET']  = nil
+    ENV['SALESFORCE_API_VERSION']    = nil
   end
 
   after do
@@ -39,7 +40,8 @@ describe Restforce do
           'SALESFORCE_CLIENT_ID'      => 'client id',
           'SALESFORCE_CLIENT_SECRET'  => 'client secret',
           'SALESFORCE_PROXY_URI'      => 'proxy',
-          'SALESFORCE_HOST'           => 'test.host.com' }.
+          'SALESFORCE_HOST'           => 'test.host.com',
+          'SALESFORCE_API_VERSION'    => '37.0' }.
         each { |var, value| ENV.stub(:[]).with(var).and_return(value) }
       end
 
@@ -50,6 +52,7 @@ describe Restforce do
       its(:client_secret)  { should eq 'client secret' }
       its(:proxy_uri)      { should eq 'proxy' }
       its(:host)           { should eq 'test.host.com' }
+      its(:api_version)    { should eq '37.0' }
     end
   end
 


### PR DESCRIPTION
All other options have a related ENV var from the system that's hosting this gem.  api_version defaults to 26.0 but there's no way to set this from an ENV var upon deployment.  This change will allow the variable to be set or it will default to v26.0 if none was specified.