### PR TITLE
Fix Travis CI by specifying a version of Rack

### DIFF
--- a/Gemfile.travis
+++ b/Gemfile.travis
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
+gem 'rack', '~> 1.6.4'
 gem 'jruby-openssl', :platforms => :jruby


### PR DESCRIPTION
Travis has been failing because it was attempting to install a new version of Rack (a dependency of Faye) which only supports late Ruby versions. This fixes the problem by specifying an earlier working version of Rack.