### PR TITLE
Test on Ruby 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3.1
   - jruby-19mode
   - rbx-2
 gemfile:


### PR DESCRIPTION
We're not running tests on Ruby 2.3 which is a bit sad, so let's start doing that.