### PR TITLE
Add Salesforce Document support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.3.x (Jul 22, 2016)
+
+* Added ability to download documents (@jhelbig)
+
+    Example
+
+        document = client.query('select Id, Name, Body from Document').first
+        File.open(document.Name, 'wb') { |f| f.write(document.Body) }
+
 ## 2.3.0 (Jul 15, 2016)
 
 * Allow the Salesforce API version to be specified with a `SALESFORCE_API_VERSION` environment variable (@jhelbig)

--- a/README.md
+++ b/README.md
@@ -439,13 +439,19 @@ _See also: [Inserting or updating blob data](http://www.salesforce.com/us/develo
 
 * * *
 
-### Downloading Attachments
+### Downloading Attachments and Documents
 
-Restforce also makes it incredibly easy to download Attachments:
+Restforce also makes it incredibly easy to download Attachments or Documents:
 
+##### Attachments
 ```ruby
 attachment = client.query('select Id, Name, Body from Attachment').first
 File.open(attachment.Name, 'wb') { |f| f.write(attachment.Body) }
+```
+##### Documents
+```ruby
+document = client.query('select Id, Name, Body from Document').first
+File.open(document.Name, 'wb') { |f| f.write(document.Body) }
 ```
 
 * * *

--- a/lib/restforce.rb
+++ b/lib/restforce.rb
@@ -11,6 +11,7 @@ module Restforce
   autoload :Collection,     'restforce/collection'
   autoload :Middleware,     'restforce/middleware'
   autoload :Attachment,     'restforce/attachment'
+  autoload :Document,       'restforce/document'
   autoload :UploadIO,       'restforce/upload_io'
   autoload :SObject,        'restforce/sobject'
   autoload :Client,         'restforce/client'

--- a/lib/restforce/document.rb
+++ b/lib/restforce/document.rb
@@ -1,0 +1,21 @@
+module Restforce
+  class Document < Restforce::SObject
+    # Public: Returns the body of the document.
+    #
+    # Examples
+    #
+    #   document = client.query('select Id, Name, Body from Document').first
+    #   File.open(document.Name, 'wb') { |f| f.write(document.Body) }
+    def Body
+      ensure_id && ensure_body
+      @client.get(super).body
+    end
+
+    private
+
+    def ensure_body
+      return true if self.Body?
+      raise 'You need to query the Body for the record first.'
+    end
+  end
+end

--- a/lib/restforce/mash.rb
+++ b/lib/restforce/mash.rb
@@ -24,7 +24,7 @@ module Restforce
           # of sobject records.
           Restforce::Collection
         elsif val.key? 'attributes'
-          case(val['attributes']['type'])
+          case (val['attributes']['type'])
           when /^Attachment$/
             Restforce::Attachment
           when /^Document$/

--- a/lib/restforce/mash.rb
+++ b/lib/restforce/mash.rb
@@ -24,8 +24,11 @@ module Restforce
           # of sobject records.
           Restforce::Collection
         elsif val.key? 'attributes'
-          if val['attributes']['type'] == 'Attachment'
+          case(val['attributes']['type'])
+          when /^Attachment$/
             Restforce::Attachment
+          when /^Document$/
+            Restforce::Document
           else
             # When the hash contains an attributes key, it should be considered an
             # sobject record

--- a/lib/restforce/mash.rb
+++ b/lib/restforce/mash.rb
@@ -25,9 +25,9 @@ module Restforce
           Restforce::Collection
         elsif val.key? 'attributes'
           case (val['attributes']['type'])
-          when /^Attachment$/
+          when "Attachment"
             Restforce::Attachment
-          when /^Document$/
+          when "Document"
             Restforce::Document
           else
             # When the hash contains an attributes key, it should be considered an

--- a/spec/unit/document_spec.rb
+++ b/spec/unit/document_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Restforce::Document do
+  let(:client)   { double(Restforce::AbstractClient) }
+  let(:body_url) { '/services/data/v26.0/sobjects/Document/00PG0000006Hll5MAC/Body' }
+  let(:hash)     { { 'Id' => '1234', 'Body' => body_url } }
+  let(:sobject)  { described_class.new(hash, client) }
+
+  describe '.Body' do
+    it 'requests the body' do
+      client.should_receive(:get).with(body_url).
+        and_return(double('response').as_null_object)
+      sobject.Body
+    end
+  end
+end

--- a/spec/unit/mash_spec.rb
+++ b/spec/unit/mash_spec.rb
@@ -26,6 +26,11 @@ describe Restforce::Mash do
         let(:input) { { 'attributes' => { 'type' => 'Attachment' } } }
         it { should eq Restforce::Attachment }
       end
+
+      context 'when the sobject type is a Document' do
+        let(:input) { { 'attributes' => { 'type' => 'Document' } } }
+        it { should eq Restforce::Document }
+      end
     end
 
     context 'else' do


### PR DESCRIPTION
Noticed documents were not supported.  Attachments and Documents are similar enough and both contain 'Body' attributes that host the file information.  This was essentially a copy and replace with the Attachment class.