### PR TITLE
bump default api_version to 38.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ end
 
 ### API versions
 
-By default, the gem defaults to using version 26.0 (Winter '13) of the Salesforce API.
+By default, the gem defaults to using version 38.0 (Winter '17) of the Salesforce API.
 Some more recent API endpoints will not be available without moving to a more recent
 version - if you're trying to use a method that is unavailable with your API version,
 Restforce will raise an `APIVersionError`.

--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -88,7 +88,7 @@ module Restforce
       end
     end
 
-    option :api_version, default: lambda { ENV['SALESFORCE_API_VERSION'] || '26.0' }
+    option :api_version, default: lambda { ENV['SALESFORCE_API_VERSION'] || '38.0' }
 
     # The username to use during login.
     option :username, default: lambda { ENV['SALESFORCE_USERNAME'] }

--- a/spec/fixtures/sobject/query_paginated_first_page_response.json
+++ b/spec/fixtures/sobject/query_paginated_first_page_response.json
@@ -1,7 +1,7 @@
 {
   "totalSize" : 2,
   "done" : false,
-  "nextRecordsUrl" : "/services/data/v26.0/query/01gD",
+  "nextRecordsUrl" : "/services/data/v38.0/query/01gD",
   "records" : [ {
     "attributes" : {
       "type" : "Whizbang",

--- a/spec/unit/attachment_spec.rb
+++ b/spec/unit/attachment_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Restforce::Attachment do
   let(:client)   { double(Restforce::AbstractClient) }
-  let(:body_url) { '/services/data/v26.0/sobjects/Attachment/00PG0000006Hll5MAC/Body' }
+  let(:body_url) { '/services/data/v38.0/sobjects/Attachment/00PG0000006Hll5MAC/Body' }
   let(:hash)     { { 'Id' => '1234', 'Body' => body_url } }
   let(:sobject)  { described_class.new(hash, client) }
 

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -20,7 +20,7 @@ describe Restforce do
     it { should be_a Restforce::Configuration }
 
     context 'by default' do
-      its(:api_version)            { should eq '26.0' }
+      its(:api_version)            { should eq '38.0' }
       its(:host)                   { should eq 'login.salesforce.com' }
       its(:authentication_retries) { should eq 3 }
       its(:adapter)                { should eq Faraday.default_adapter }

--- a/spec/unit/document_spec.rb
+++ b/spec/unit/document_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Restforce::Document do
   let(:client)   { double(Restforce::AbstractClient) }
-  let(:body_url) { '/services/data/v26.0/sobjects/Document/00PG0000006Hll5MAC/Body' }
+  let(:body_url) { '/services/data/v38.0/sobjects/Document/00PG0000006Hll5MAC/Body' }
   let(:hash)     { { 'Id' => '1234', 'Body' => body_url } }
   let(:sobject)  { described_class.new(hash, client) }
 


### PR DESCRIPTION
fixes issues with older versions, for example: https://github.com/ejholmes/restforce/issues/167 describes one such potential issue with older api versions.