### PR TITLE
No credentials in cache keys

### DIFF
--- a/Gemfile.travis
+++ b/Gemfile.travis
@@ -4,3 +4,4 @@ gemspec
 gem 'rake'
 gem 'rack', '~> 1.6.4'
 gem 'jruby-openssl', :platforms => :jruby
+gem 'public_suffix', '2.0.3'

--- a/lib/restforce/concerns/caching.rb
+++ b/lib/restforce/concerns/caching.rb
@@ -19,6 +19,10 @@ module Restforce
       def cache
         options[:cache]
       end
+
+      def params_to_ignore
+        (super + ["Auth"]).uniq
+      end
     end
   end
 end

--- a/lib/restforce/concerns/caching.rb
+++ b/lib/restforce/concerns/caching.rb
@@ -19,10 +19,6 @@ module Restforce
       def cache
         options[:cache]
       end
-
-      def params_to_ignore
-        (super + ["Auth"]).uniq
-      end
     end
   end
 end

--- a/lib/restforce/middleware/caching.rb
+++ b/lib/restforce/middleware/caching.rb
@@ -12,13 +12,17 @@ module Restforce
     # We don't want to cache requests for different clients, so append the
     # oauth token to the cache key.
     def cache_key(env)
-      super(env) +
-        env[:request_headers][Restforce::Middleware::Authorization::AUTH_HEADER].
-          gsub(/\s/, '')
+      super(env) + hashed_auth_header(env)
     end
 
     def use_cache?
       @options.fetch(:use_cache, true)
+    end
+
+    def hashed_auth_header(env)
+      Digest::SHA1.hexdigest(
+        env[:request_headers][Restforce::Middleware::Authorization::AUTH_HEADER]
+      )
     end
   end
 end

--- a/lib/restforce/version.rb
+++ b/lib/restforce/version.rb
@@ -1,3 +1,3 @@
 module Restforce
-  VERSION = '2.4.3.pre1'
+  VERSION = '2.4.3.pre2'
 end

--- a/lib/restforce/version.rb
+++ b/lib/restforce/version.rb
@@ -1,3 +1,3 @@
 module Restforce
-  VERSION = '2.4.2'
+  VERSION = '2.4.3.pre1'
 end

--- a/lib/restforce/version.rb
+++ b/lib/restforce/version.rb
@@ -1,3 +1,3 @@
 module Restforce
-  VERSION = '2.4.3.pre2'
+  VERSION = '2.4.3.pre3'
 end


### PR DESCRIPTION
While instrumenting our code with zipkin we noticed the auth headers being included in cache keys. While hashing them isn't perfect it's better than what we're doing now.