### PR TITLE
Deprecate ruby 1.9.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2
   - 2.3.1
-  - jruby-19mode
-  - rbx-2
   - ruby-2.4.0-preview2
 gemfile:
   - Gemfile.travis
@@ -14,6 +11,3 @@ script:
   - bundle exec rubocop
   - bundle exec rspec spec
 sudo: false
-matrix:
-  allow_failures:
-  - rvm: rbx-2

--- a/lib/restforce/version.rb
+++ b/lib/restforce/version.rb
@@ -1,3 +1,3 @@
 module Restforce
-  VERSION = '2.4.2'
+  VERSION = '2.5.0.pre1'
 end

--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -16,18 +16,12 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Restforce::VERSION
 
-  gem.required_ruby_version = '>= 1.9.3'
+  gem.required_ruby_version = '>= 2.0'
 
   gem.add_dependency 'faraday', '~> 0.9.0'
   gem.add_dependency 'faraday_middleware', '>= 0.8.8'
 
-  # Ruby 2.4 requires JSON 2.0, but that doesn't work with old pre-2.0.0 versions of Ruby.
-  # See https://github.com/ejholmes/restforce/issues/260.
-  if RUBY_VERSION =~ /^1.9/
-    gem.add_dependency 'json', ['>= 1.7.5', '< 1.9.0']
-  else
-    gem.add_dependency 'json', '>= 1.7.5'
-  end
+  gem.add_dependency 'json', '>= 1.7.5'
 
   gem.add_dependency 'hashie', ['>= 1.2.0', '< 4.0']
 


### PR DESCRIPTION
This is a PR with no changes to show off that master doesn't build due to something changing in the gem dependencies. 

/cc https://github.com/ejholmes/restforce/pull/273