### PR TITLE
Add a Tooling API example to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,16 @@ call `Restforce.tooling` instead of `Restforce.new`:
 client = Restforce.tooling(...)
 ```
 
+You can use the Tooling API to add fields to existing objects. For example, add "Twitter Username" to the default "Account" object:
+
+```ruby
+client = Restforce.tooling(...)
+client.create!("CustomField", { 
+  "FullName" => "Account.orgnamespace__twitter_username__c", 
+  "Metadata" => { type: "Text", label: "Twitter Username", length: 15 },
+})
+```
+
 ## Links
 
 If you need a full Active Record experience, may be you can use


### PR DESCRIPTION
As per requested in https://github.com/ejholmes/restforce/issues/268, add an example that shows how the Tooling API can be used.

The example creates a "Twitter Username" field on the standard "Account" object.