### PR TITLE
Custom Header middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,23 @@ to do some custom error handling. The bang methods will raise exceptions, while 
 non-bang methods will return false in the event that an exception is raised. This
 works similarly to ActiveRecord.
 
+
+### Custom Headers
+
+Salesforce allows the addition of
+[custom headers](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/headers.htm)
+in REST API requests to trigger specific logic. In order to pass any custom headers along with API requests,
+you can specify a hash of `:request_headers`  upon client initialization. The example below demonstrates how
+to include the `sforce-auto-assign` header in all client HTTP requests:
+
+```ruby
+client = Restforce.new(oauth_token: 'access_token',
+                       instance_url: 'instance url',
+                       api_version: '38.0',
+                       request_headers: { 'sforce-auto-assign' => 'FALSE' })
+
+```
+
 * * *
 
 ### query

--- a/lib/restforce/concerns/base.rb
+++ b/lib/restforce/concerns/base.rb
@@ -50,6 +50,10 @@ module Restforce
       #
       #        :authentication_callback - A Proc that is called with the response body
       #                                   after a successful authentication.
+      #
+      #        :request_headers         - A hash containing custom headers that will be
+      #                                   appended to each request
+
       def initialize(opts = {})
         raise ArgumentError, 'Please specify a hash of options' unless opts.is_a?(Hash)
 

--- a/lib/restforce/concerns/connection.rb
+++ b/lib/restforce/concerns/connection.rb
@@ -52,6 +52,8 @@ module Restforce
                            options if Restforce.log?
           # Compress/Decompress the request/response
           builder.use      Restforce::Middleware::Gzip, self, options
+          # Inject custom headers into requests
+          builder.use      Restforce::Middleware::CustomHeaders, self, options
 
           builder.adapter  adapter
         end

--- a/lib/restforce/middleware.rb
+++ b/lib/restforce/middleware.rb
@@ -11,6 +11,7 @@ module Restforce
     autoload :Caching,        'restforce/middleware/caching'
     autoload :Logger,         'restforce/middleware/logger'
     autoload :Gzip,           'restforce/middleware/gzip'
+    autoload :CustomHeaders,  'restforce/middleware/custom_headers'
 
     def initialize(app, client, options)
       @app = app

--- a/lib/restforce/middleware/custom_headers.rb
+++ b/lib/restforce/middleware/custom_headers.rb
@@ -1,0 +1,11 @@
+module Restforce
+  # Middleware that allows you to specify custom request headers when initializing Restforce client
+  class Middleware::CustomHeaders < Restforce::Middleware
+    def call(env)
+      headers = @options[:request_headers]
+      env[:request_headers].merge!(headers) if headers.is_a?(Hash)
+
+      @app.call(env)
+    end
+  end
+end

--- a/lib/restforce/middleware/custom_headers.rb
+++ b/lib/restforce/middleware/custom_headers.rb
@@ -1,5 +1,6 @@
 module Restforce
-  # Middleware that allows you to specify custom request headers when initializing Restforce client
+  # Middleware that allows you to specify custom request headers
+  # when initializing Restforce client
   class Middleware::CustomHeaders < Restforce::Middleware
     def call(env)
       headers = @options[:request_headers]

--- a/spec/support/client_integration.rb
+++ b/spec/support/client_integration.rb
@@ -25,7 +25,8 @@ module ClientIntegrationExampleGroup
           security_token: security_token,
           client_id: client_id,
           client_secret: client_secret,
-          cache: cache
+          cache: cache,
+          request_headers: { 'x-test-header' => 'Test Header' }
         }
       end
 

--- a/spec/unit/middleware/custom_headers_spec.rb
+++ b/spec/unit/middleware/custom_headers_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Restforce::Middleware::CustomHeaders do
+
+  describe '.call' do
+    subject { lambda { middleware.call(env) } }
+
+    context 'when :request_headers are a Hash' do
+      let(:options) { { request_headers: { 'x-test-header' => 'Test Value' } } }
+
+      it { should change { env[:request_headers]['x-test-header'] }.to eq 'Test Value' }
+    end
+
+    context 'when :request_headers are not a Hash' do
+      let(:options) { { request_headers: 'bad header' } }
+
+      it { should_not change { env[:request_headers] } }
+    end
+  end
+end

--- a/spec/unit/middleware/custom_headers_spec.rb
+++ b/spec/unit/middleware/custom_headers_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Restforce::Middleware::CustomHeaders do
-
   describe '.call' do
     subject { lambda { middleware.call(env) } }
 


### PR DESCRIPTION
## Problem
The Restforce gem does not currently support custom HTTP request headers out of the box.  It's currently possible for users to define their own middleware in their application to handle request header injection (discussion here: https://github.com/ejholmes/restforce/issues/109).  While this works, there is logic in Salesforce API interactions that can be triggered based on the presence of custom headers, so it is justifiable to support this in Restforce.

## Solution
Added `Restforce::Middleware::CustomHeaders` to the gem.  This allows user to pass a hash of custom headers values into the client when initializing.  If a valid hash is provided, the values in the hash are injected into the headers of every HTTP request made by that specific client instance.

Here's an example (I added this to the README as well):
```ruby
client = Restforce.new(oauth_token: 'access_token',
                       instance_url: 'instance url',
                       api_version: '38.0',
                       request_headers: { 'sforce-auto-assign' => 'FALSE' })

```

## Details
A couple things:
- It is technically possible to specify custom headers with same keys as pre-existing Authorization headers.  The custom headers will overwrite the pre-existing Auth headers, I'm ok with changing the code to prefer the Auth headers and never overwrite them, although the argument could be made that users may _want_ to override those headers for whatever reason.
- I added documentation for this argument but I'm no copywriter, feel free to suggest changes there.