### PR TITLE
Fix the build of Ruby 2.4 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,13 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.1
-  - ruby-2.4.0-preview2
+  - ruby-2.4.0
 gemfile:
   - Gemfile.travis
 script:
   - bundle exec rubocop
   - bundle exec rspec spec
 sudo: false
+before_install:
+  - gem update --system
+  - gem update bundler


### PR DESCRIPTION
* Switches from `ruby-2.4.0-preview2` to the final version
* Update Rubygems and Bundler to the latest version before running the build (to fix issue when building `rainbow`)