### PR TITLE
Disable Hashie warnings for re-defined methods such as length

### DIFF
--- a/lib/restforce/mash.rb
+++ b/lib/restforce/mash.rb
@@ -2,6 +2,8 @@ require 'hashie/mash'
 
 module Restforce
   class Mash < Hashie::Mash
+    disable_warnings if respond_to?(:disable_warnings)
+
     class << self
       # Pass in an Array or Hash and it will be recursively converted into the
       # appropriate Restforce::Collection, Restforce::SObject and


### PR DESCRIPTION
# Description of the issue fixed by this pr
When using `hashie >= v3.5.0` any `Client#describe` call currently results in lots of

```
You are setting a key that conflicts with a built-in method Restforce::Mash#length defined in Hash. This can cause unexpected behavior when accessing the key via as a property. You can still access the key via the #[] method.
```

warnings, bc. of the `fields`-Array as `fields` have a `length` key.

# Background
The logging layer of Hashie was introduced in `hashie v3.5.0`. And the `disable_warnings` method was introduced in `hashie v3.5.2`. See https://github.com/intridea/hashie/blob/master/CHANGELOG.md.

Other gems using `hashie` went this way as well, see for example https://github.com/elastic/elasticsearch-rails/issues/666.