### PR TITLE
Raise error in upsert! when external id is missing

### DIFF
--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -364,6 +364,9 @@ module Restforce
         attrs = attrs.dup
         external_id =
           extract_case_insensitive_string_or_symbol_key_from_hash!(attrs, field)
+        if field.to_s != "Id" && (external_id.nil? || external_id.strip.empty?)
+          raise ArgumentError, 'Specified external ID field missing from provided attributes'
+        end
 
         response =
           if field.to_s == "Id" && (external_id.nil? || external_id.strip.empty?)

--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -317,7 +317,7 @@ module Restforce
       # Raises an exception if an error is returned from Salesforce.
       def update!(sobject, attrs)
         id = attrs.fetch(attrs.keys.find { |k, v| k.to_s.downcase == 'id' }, nil)
-        raise ArgumentError, 'Id field missing from attrs.' unless id
+        raise ArgumentError, 'ID field missing from provided attributes' unless id
         attrs_without_id = attrs.reject { |k, v| k.to_s.downcase == "id" }
         api_patch "sobjects/#{sobject}/#{id}", attrs_without_id
         true

--- a/spec/integration/abstract_client_spec.rb
+++ b/spec/integration/abstract_client_spec.rb
@@ -133,7 +133,7 @@ shared_examples_for Restforce::AbstractClient do
   describe '.update' do
     context 'with missing Id' do
       subject { lambda { client.update('Account', Name: 'Foobar') } }
-      it { should raise_error ArgumentError, 'Id field missing from attrs.' }
+      it { should raise_error ArgumentError, 'ID field missing from provided attributes' }
     end
 
     context 'with invalid Id' do

--- a/spec/unit/concerns/api_spec.rb
+++ b/spec/unit/concerns/api_spec.rb
@@ -348,6 +348,14 @@ describe Restforce::Concerns::API do
         end
       end
 
+      context 'when the external id field is missing from the attrs' do
+        let(:attrs) { Hash.new }
+        it 'raises an argument error' do
+          expect { client.upsert!(sobject, field, attrs) }.to raise_error ArgumentError,
+            'Specified external ID field missing from provided attributes'
+        end
+      end
+
       context 'when using Id as the attribute' do
         let(:field) { :Id }
         let(:attrs) { { 'Id' => '4321' } }

--- a/spec/unit/concerns/api_spec.rb
+++ b/spec/unit/concerns/api_spec.rb
@@ -318,7 +318,7 @@ describe Restforce::Concerns::API do
 
       context 'when the id field is missing from the attrs' do
         subject { lambda { result } }
-        it { should raise_error ArgumentError, 'Id field missing from attrs.' }
+        it { should raise_error ArgumentError, 'ID field missing from provided attributes' }
       end
     end
 


### PR DESCRIPTION
Discovered as a result of https://github.com/ejholmes/restforce/issues/159 - when the external id was missing after being deleted, the error surfaced as `NoMethodError·undefined method 'gsub' for nil:NilClass` since `upsert!` would try to URI encode `nil` (https://github.com/ejholmes/restforce/blame/master/lib/restforce/concerns/api.rb#L374)