### PR TITLE
Use SSL options for authentication request

### DIFF
--- a/lib/restforce/middleware/authentication.rb
+++ b/lib/restforce/middleware/authentication.rb
@@ -81,7 +81,8 @@ module Restforce
 
     def faraday_options
       { url: "https://#{@options[:host]}",
-        proxy: @options[:proxy_uri] }.reject { |k, v| v.nil? }
+        proxy: @options[:proxy_uri],
+        ssl: @options[:ssl] }
     end
   end
 end

--- a/spec/unit/middleware/authentication_spec.rb
+++ b/spec/unit/middleware/authentication_spec.rb
@@ -5,7 +5,8 @@ describe Restforce::Middleware::Authentication do
     { host: 'login.salesforce.com',
       proxy_uri: 'https://not-a-real-site.com',
       authentication_retries: retries,
-      adapter: :net_http }
+      adapter: :net_http,
+      ssl: { version: :TLSv1_2 } }
   end
 
   describe '.authenticate!' do
@@ -80,6 +81,10 @@ describe Restforce::Middleware::Authentication do
           should include FaradayMiddleware::ParseJson, Faraday::Adapter::Typhoeus
         }
       end
+    end
+
+    it "should have SSL config set" do
+      connection.ssl[:version].should eq(:TLSv1_2)
     end
   end
 end


### PR DESCRIPTION
This change ensures that the SSL options passed to the request are also used for the authentication request (if it is needed) in addition to the actual resource request. This allows enforcement of an SSL version (eg. TLS v1.2) for increased security.

See also: #238