### PR TITLE
Fix Faraday version for development and testing to v0.11.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ gemspec
 
 gem 'rake'
 gem 'jruby-openssl', :platforms => :jruby
+gem 'faraday', '~> 0.11.0'
 
 group :development do
   gem 'guard-rspec'

--- a/Gemfile.travis
+++ b/Gemfile.travis
@@ -3,5 +3,6 @@ gemspec
 
 gem 'rake'
 gem 'rack', '~> 1.6.4'
+gem 'faraday', '~> 0.11.0'
 gem 'jruby-openssl', :platforms => :jruby
 gem 'public_suffix', '2.0.3'


### PR DESCRIPTION
The gem is compatible with versions of Faraday up to v1.0 (yet to be released! - currently the latest is v0.12.1) but at present, our tests only work with v0.11.0 and earlier (the current version is v0.12.1, so we're not too far behind).

This updates our `Gemfile`s to lock to this version so tests will pass again in Travis. I'll look as soon as I can at fixing the tests for `Restforce::Concerns::Connection` so they can work with newer Faraday versions - looks like its API has changed.