### PR TITLE
Add gemspec metadata

### DIFF
--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -16,6 +16,11 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Restforce::VERSION
 
+  gem.metadata = {
+    'source_code_uri' => 'https://github.com/ejholmes/restforce',
+    'changelog_uri'   => 'https://github.com/ejholmes/restforce/blob/master/CHANGELOG.md'
+  }
+
   gem.required_ruby_version = '>= 2.0'
 
   gem.add_dependency 'faraday', ['>= 0.9.0', '<= 1.0']


### PR DESCRIPTION
Makes it easy to programatically find the source code and changelog for `restforce`, using the rubygems API. More details on the direction of travel for gemspecs is [here](https://github.com/rubygems/rubygems.org/issues/1127) and [here](https://github.com/rubygems/rubygems.org/pull/1234), and the current state is [here](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/specification.rb).