### PR TITLE
Support for data replication end points 

### DIFF
--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -453,6 +453,16 @@ module Restforce
         api_get(path).body
       end
 
+      def get_updated_between(sobject, startDate, endDate)
+        path = "sobjects/#{sobject}/updated/?start=#{startDate.utc.iso8601}&end=#{endDate.utc.iso8601}"
+        api_get(path).body
+      end
+
+      def get_deleted_between(sobject, startDate, endDate)
+        path = "sobjects/#{sobject}/deleted/?start=#{startDate.utc.iso8601}&end=#{endDate.utc.iso8601}"
+        api_get(path).body
+      end
+
       # Public: Finds recently viewed items for the logged-in user.
       #
       # limit - An optional limit that specifies the maximum number of records to be

--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -88,7 +88,7 @@ module Restforce
       end
     end
 
-    option :api_version, default: lambda { ENV['SALESFORCE_API_VERSION'] || '26.0' }
+    option :api_version, default: lambda { ENV['SALESFORCE_API_VERSION'] || '29.0' }
 
     # The username to use during login.
     option :username, default: lambda { ENV['SALESFORCE_USERNAME'] }

--- a/spec/fixtures/sobject/query_paginated_first_page_response.json
+++ b/spec/fixtures/sobject/query_paginated_first_page_response.json
@@ -1,7 +1,7 @@
 {
   "totalSize" : 2,
   "done" : false,
-  "nextRecordsUrl" : "/services/data/v26.0/query/01gD",
+  "nextRecordsUrl" : "/services/data/v29.0/query/01gD",
   "records" : [ {
     "attributes" : {
       "type" : "Whizbang",

--- a/spec/unit/concerns/api_spec.rb
+++ b/spec/unit/concerns/api_spec.rb
@@ -427,6 +427,36 @@ describe Restforce::Concerns::API do
     end
   end
 
+  describe '.get_updated_between' do
+    let(:sobject) {'Account'}
+    let(:endTime) {Time.now}
+    let(:startTime) {Time.now - 100}
+    subject(:result) {client.get_updated_between(sobject, startTime, endTime)}
+
+
+    it 'should return the value from the api request' do
+      client.should_receive(:api_get).
+          with("sobjects/Account/updated/?start=#{startTime.utc.iso8601}&end=#{endTime.utc.iso8601}").
+          and_return(response)
+      expect(result).to eq(response.body)
+    end
+  end
+
+  describe '.get_deleted_between' do
+    let(:sobject) {'Account'}
+    let(:endTime) {Time.now}
+    let(:startTime) {Time.now - 100}
+    subject(:result) {client.get_deleted_between(sobject, startTime, endTime)}
+
+
+    it 'should return the value from the api request' do
+      client.should_receive(:api_get).
+          with("sobjects/Account/deleted/?start=#{startTime.utc.iso8601}&end=#{endTime.utc.iso8601}").
+          and_return(response)
+      expect(result).to eq(response.body)
+    end
+  end
+
   describe '.find' do
     let(:sobject)    { 'Whizbang' }
     let(:id)         { '1234' }

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -20,7 +20,7 @@ describe Restforce do
     it { should be_a Restforce::Configuration }
 
     context 'by default' do
-      its(:api_version)            { should eq '26.0' }
+      its(:api_version)            { should eq '29.0' }
       its(:host)                   { should eq 'login.salesforce.com' }
       its(:authentication_retries) { should eq 3 }
       its(:adapter)                { should eq Faraday.default_adapter }


### PR DESCRIPTION
We've needed to extend to provide support for the data replication end
points. Doing so means upgrading the api version to 29+ and implementing
two end points getUpdatedBetween and getDeletedBetween which take two
Time object representing the beginning and end of a time window you wish
salesforce to provide you notification of updated