### PR TITLE
Undefined method strip when external_id is a Fixnum

### DIFF
--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -363,7 +363,7 @@ module Restforce
       def upsert!(sobject, field, attrs)
         attrs = attrs.dup
         external_id =
-          extract_case_insensitive_string_or_symbol_key_from_hash!(attrs, field)
+          extract_case_insensitive_string_or_symbol_key_from_hash!(attrs, field).to_s
         if field.to_s != "Id" && (external_id.nil? || external_id.strip.empty?)
           raise ArgumentError, 'Specified external ID field missing from provided ' \
                                'attributes'

--- a/spec/unit/concerns/api_spec.rb
+++ b/spec/unit/concerns/api_spec.rb
@@ -413,6 +413,23 @@ describe Restforce::Concerns::API do
         end
       end
     end
+
+    describe '.upsert! with Fixnum argument' do
+      let(:sobject)    { 'Whizbang' }
+      let(:field)      { :External_ID__c }
+      let(:attrs)      { { 'External_ID__c' => 1234 } }
+      subject(:result) { client.upsert!(sobject, field, attrs) }
+
+      context 'when the record is found and updated' do
+        it 'returns true' do
+          response.body.stub :[]
+          client.should_receive(:api_patch).
+            with('sobjects/Whizbang/External_ID__c/1234', {}).
+            and_return(response)
+          expect(result).to be_true
+        end
+      end
+    end
   end
 
   describe '.destroy!' do


### PR DESCRIPTION
If external Id is a Fixnum extract_case_insensitive_string_or_symbol_key_from_hash will return it as a Fixnum too, and we'll get Undefined method strip for Fixnum. Happens for symbols too.